### PR TITLE
feat: User model, handler, router 모듈 선언 및 re-export 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,9 @@
-[package]
-name = "rust-blog-backend"
-version = "0.1.0"
-edition = "2021"
-
 [dependencies]
-postgres = "0.19"
-serde = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+warp = "0.3"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
+tokio-postgres = { version = "0.7", features = ["with-uuid-0_8"] }
+dotenv = "0.15"
+argon2 = "0.5.3"
+rand = "0.8"

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,30 @@
+use tokio_postgres::{Client, NoTls, Error};
+use std::env;
+
+pub async fn connect_db() -> Result<Client, Error> {
+    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let (client, connection) = tokio_postgres::connect(&db_url, NoTls).await?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("데이터베이스 연결 오류: {}", e); 
+        }
+    });
+    Ok(client) 
+}
+
+pub async fn init_db() -> Result<(), Error> {
+    let client = connect_db().await?;
+    client.batch_execute(
+        "
+        CREATE TABLE IF NOT EXISTS users (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR NOT NULL,
+            email VARCHAR NOT NULL,
+            password VARCHAR NOT NULL
+        )
+        ",
+    )
+    .await?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,83 +1,24 @@
-use postgres::{Client, NoTls};
-use postgres::Error as PostgresError;
-use std::net::{TcpListener, TcpStream};
-use std::io::{Read, Write};
-use std::env;
+use warp::Filter;
 
-#[macro_use]
-extern crate serde_derive;
+mod db;
+mod users;
 
+#[tokio::main]
+async fn main() {
+    dotenv::dotenv().ok();
 
-#[derive(Serialize, Deserialize)]
-struct User {
-    id: Option<i32>,
-    name: String,
-    email: String,
-}
-
-
-
-
-const OK_RESPONSE: &str = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
-const NOT_FOUND: &str = "HTTP/1.1 404 NOT Found\r\n\r\n";
-const INTERNAL_SERVER_ERROR: &str = "HTTP/1.1 500 INTERNAL SERVER ERROR\r\n\r\n";
-
-
-
-fn main() {
-
-    if let Err(e) = set_database() {
-        eprintln!("데이터베이스 설정 오류: {}", e);
+    if let Err(e) = db::init_db().await {
+        eprintln!("Failed to initialize database: {}", e);
         return;
     }
 
-
-    let listener = TcpListener::bind("0.0.0.0:8000").expect("포트 8000에 바인드 실패");
-    println!("서버가 8000번 포트에서 시작되었습니다");
+    let user_routes = users::routes::user_routes();
 
 
-    for stream in listener.incoming() {
-        match stream {
-            Ok(mut stream) => {
-                handle_client(&mut stream);
-            }
-            Err(e) => {
-                eprintln!("연결 오류: {}", e);
-            }
-        }
-    }
-}
+    let routes = user_routes
+        .with(warp::log("api"));
 
-
-fn set_database() -> Result<(), PostgresError> {
-
-    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL 환경 변수가 설정되어 있어야 합니다");
-    let mut client = Client::connect(&db_url, NoTls)?;
-
-
-    client.execute(
-        "CREATE TABLE IF NOT EXISTS users (
-            id SERIAL PRIMARY KEY,
-            name VARCHAR NOT NULL,
-            email VARCHAR NOT NULL
-        )",
-        &[],
-    )?;
-
-    Ok(())
-}
-
-
-fn handle_client(stream: &mut TcpStream) {
-  
-    let mut buffer = [0; 512];
-    if let Err(e) = stream.read(&mut buffer) {
-        eprintln!("스트림에서 읽기 실패: {}", e);
-        return;
-    }
-
-
-    if let Err(e) = stream.write_all(OK_RESPONSE.as_bytes()) {
-        eprintln!("스트림에 쓰기 실패: {}", e);
-    }
+    warp::serve(routes)
+        .run(([0, 0, 0, 0], 8080))
+        .await;
 }

--- a/src/users/handlers.rs
+++ b/src/users/handlers.rs
@@ -1,0 +1,42 @@
+use super::models::User;
+use crate::db;
+use warp::http::StatusCode;
+use std::convert::Infallible;
+use warp::reply::Json;
+use serde_json::json;
+use argon2::{self, Config};
+use rand::Rng;
+
+pub async fn create_user(new_user: User) -> Result<impl warp::Reply, Infallible> {
+    match db::connect_db().await {
+        Ok(client) => {
+            // 비밀번호 해싱
+            let salt: [u8; 32] = rand::thread_rng().gen();
+            let config = Config::default();
+            let hash = argon2::hash_encoded(new_user.password.as_bytes(), &salt, &config).unwrap();
+
+            let result = client.execute(
+                "INSERT INTO users (name, email, password) VALUES ($1, $2, $3)",
+                &[&new_user.name, &new_user.email, &hash],
+            ).await;
+
+            match result {
+                Ok(_) => Ok(warp::reply::with_status("User created", StatusCode::CREATED)),
+                Err(e) => {
+                    eprintln!("Error creating user: {}", e);
+                    Ok(warp::reply::with_status(
+                        "Failed to create user",
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                    ))
+                }
+            }
+        },
+        Err(e) => {
+            eprintln!("Database connection error: {}", e);
+            Ok(warp::reply::with_status(
+                "Database connection error",
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ))
+        }
+    }
+}

--- a/src/users/mod.rs
+++ b/src/users/mod.rs
@@ -1,0 +1,7 @@
+pub mod models;
+pub mod handlers;
+pub mod routes;
+
+pub use models::*;
+pub use handlers::*;
+pub use routes::*;

--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct User {
+    pub id: Option<i32>,
+    pub name: String,
+    pub email: String,
+    pub password: String,
+}

--- a/src/users/routes.rs
+++ b/src/users/routes.rs
@@ -1,0 +1,23 @@
+use warp::Filter;
+use super::handlers;
+use super::models::User;
+
+pub fn user_routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    let users_base = warp::path("users");
+
+    let create_user = users_base
+        .and(warp::post())
+        .and(json_body())
+        .and_then(handlers::create_user);
+
+    let get_user = users_base
+        .and(warp::path::param::<i32>())
+        .and(warp::get())
+        .and_then(handlers::get_user);
+
+    create_user.or(get_user)
+}
+
+fn json_body() -> impl Filter<Extract = (User,), Error = warp::Rejection> + Clone {
+    warp::body::json()
+}


### PR DESCRIPTION
## Overview

- 사용자가 새로운 계정을 생성할 수 있는 API 엔드포인트 구현
- 비밀번호를 `Argon2` 알고리즘으로 해싱하여 저장
- 데이터베이스에 사용자 정보를 저장하는 로직 추가
- `User` 구조체 정의
- `User` models, handlers, routes 모듈 생성
- 메인 함수 및 `Warp` 설정
- 데이터베이스 모듈 추가 (연결 및 초기화 기능 포함)
- `Cargo.toml`에 필요한 의존성 추가